### PR TITLE
Add Docker deployment with Nginx load balancer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Ignore git metadata and documentation
+.git
+.gitignore
+README.md
+
+# Exclude development artifacts
+bin/
+*.log
+
+# Exclude compose and nginx config from image context
+docker-compose.yml
+nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.20-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o kv-g
+
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=build /app/kv-g /usr/local/bin/kv-g
+ENTRYPOINT ["kv-g"]
+CMD ["--port", "8081", "--id", "node1"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,24 @@ Este projeto implementa um KV-Store (Key-Value Store) distribuído usando Go, co
 ## Requisitos
 
 - [Go](https://golang.org/dl/) (v1.16 ou superior)
+- [Docker](https://www.docker.com/) e Docker Compose (para execução via contêineres)
 - Um ambiente que permita múltiplas instâncias rodando (múltiplos terminais ou servidores).
+
+## Execução com Docker
+
+É possível levantar três nós da aplicação e um balanceador de carga Nginx usando o Docker Compose incluso neste repositório:
+
+```bash
+docker compose up -d
+```
+
+O Nginx ficará exposto na porta **8080**, encaminhando o tráfego para os três nós. Para interagir com o cluster via CLI, abra um shell em um dos nós e utilize o modo `--cli-only`:
+
+```bash
+docker compose exec node1 sh -c "printf 'put chave valor\nexit\n' | kv-g --port 8081 --id node1 --cli-only"
+```
+
+Substitua `node1` por `node2` ou `node3` para enviar comandos a outros nós.
 
 ## Como Testar o Projeto
 
@@ -22,7 +39,7 @@ Clone o repositório para a sua máquina:
 
 ```bash
 git clone https://github.com/bquerino/kv-golang.git
-cd kvstore-golang
+cd kv-golang
 ```
 
 ### 2. Executar Múltiplos Nós
@@ -47,9 +64,9 @@ No segundo terminal, você pode rodar o nó 2:
 go run main.go --port=8082 --id=node2
 ```
 
-**Terminal 2: Rodar o Nó 3**
+**Terminal 3: Rodar o Nó 3**
 
-No segundo terminal, você pode rodar o nó 2:
+No terceiro terminal, você pode rodar o nó 3:
 
 ```bash
 go run main.go --port=8083 --id=node3
@@ -70,7 +87,7 @@ Após iniciar os nós, você pode interagir com o KV-Store usando os comandos se
 
 #### Comando put
 
-No terminal do nó, insira uma chave e valor usando o comando set:
+No terminal do nó, insira uma chave e valor usando o comando put:
 
 ```bash
 put chave valor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.9"
+services:
+  node1:
+    build: .
+    command: ["--port", "8081", "--id", "node1"]
+    ports:
+      - "8081:8081"
+  node2:
+    build: .
+    command: ["--port", "8082", "--id", "node2"]
+    ports:
+      - "8082:8082"
+  node3:
+    build: .
+    command: ["--port", "8083", "--id", "node3"]
+    ports:
+      - "8083:8083"
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - node1
+      - node2
+      - node3

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+events {}
+stream {
+    upstream kv_backend {
+        server node1:8081;
+        server node2:8082;
+        server node3:8083;
+    }
+
+    server {
+        listen 8080;
+        proxy_pass kv_backend;
+    }
+}


### PR DESCRIPTION
## Summary
- add Dockerfile for building the Go key-value service
- introduce docker-compose with three nodes and Nginx TCP load balancer
- configure Nginx stream load balancing for cluster nodes
- document Docker usage in README and add .dockerignore to trim build context

## Testing
- `go build ./...`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa71aad01883229fd8e08f199fa9d2