### PR TITLE
Ensure keys propagate across nodes

### DIFF
--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -1,9 +1,11 @@
 package store
 
 import (
+	"bufio"
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,6 +43,10 @@ func NewGossip(selfID, address string, interval time.Duration, vNodes int) *Goss
 		Interval:       interval,
 		ConsistentHash: NewConsistentHashing(vNodes),
 	}
+
+	// Adiciona o próprio nó à lista e ao anel de hash consistente
+	gossip.Nodes[selfID] = self
+	gossip.ConsistentHash.AddNode(self)
 
 	// Inicializa o KeyValueStore integrado com o Gossip e PageManager
 	gossip.KeyValueStore, _ = NewKeyValueStore(gossip, gossip.ConsistentHash, 5*time.Second, "data_pages.db")
@@ -117,22 +123,77 @@ func (g *Gossip) sendMessage(node *Node) {
 	fmt.Fprintf(conn, "PING from %s\n", g.Self.ID)
 }
 
-// Lida com uma conexão recebida (PING de outro nó)
+// Lida com uma conexão recebida (PING ou operações de dados)
 func (g *Gossip) handleConnection(conn net.Conn) {
 	defer conn.Close()
 
-	var nodeID string
-	fmt.Fscanf(conn, "PING from %s\n", &nodeID)
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		log.Printf("Error reading connection: %v", err)
+		return
+	}
 
-	g.Mutex.Lock()
-	defer g.Mutex.Unlock()
+	parts := strings.Fields(strings.TrimSpace(line))
+	if len(parts) == 0 {
+		return
+	}
 
-	if node, exists := g.Nodes[nodeID]; exists {
-		node.LastCheck = time.Now()
-		node.Alive = true
-		log.Printf("Received PING from node %s", node.ID)
-	} else {
-		log.Printf("Unknown node: %s", nodeID)
+	switch parts[0] {
+	case "PING":
+		if len(parts) < 3 {
+			return
+		}
+		nodeID := parts[2]
+		g.Mutex.Lock()
+		if node, exists := g.Nodes[nodeID]; exists {
+			node.LastCheck = time.Now()
+			node.Alive = true
+			log.Printf("Received PING from node %s", node.ID)
+		} else {
+			log.Printf("Unknown node: %s", nodeID)
+		}
+		g.Mutex.Unlock()
+	case "PUT":
+		if len(parts) < 3 {
+			return
+		}
+		key := parts[1]
+		value := parts[2]
+		g.KeyValueStore.putLocal(key, value)
+	case "GET":
+		if len(parts) < 2 {
+			return
+		}
+		key := parts[1]
+		value, _, found := g.KeyValueStore.getLocal(key)
+		if found {
+			fmt.Fprintf(conn, "VALUE %s\n", value)
+		} else {
+			fmt.Fprintf(conn, "NOTFOUND\n")
+		}
+	case "ELECTION":
+		if len(parts) >= 3 {
+			nodeID := parts[2]
+			g.Mutex.Lock()
+			if node, exists := g.Nodes[nodeID]; exists {
+				node.LastCheck = time.Now()
+				node.Alive = true
+			}
+			g.Mutex.Unlock()
+			fmt.Fprintf(conn, "OK\n")
+		}
+	case "COORDINATOR":
+		if len(parts) >= 2 {
+			coordID := parts[1]
+			g.Mutex.Lock()
+			if node, exists := g.Nodes[coordID]; exists {
+				g.Coordinator = node
+			}
+			g.Mutex.Unlock()
+		}
+	default:
+		log.Printf("Unknown message: %s", line)
 	}
 }
 
@@ -288,4 +349,44 @@ func (g *Gossip) PrintNodes() {
 		}
 		log.Printf("Node: %s, Address: %s, Status: %s", id, node.Address, status)
 	}
+}
+
+// Envia uma operação PUT para outro nó responsável pela chave
+func (g *Gossip) sendPutToNode(node *Node, key, value string) {
+	conn, err := net.Dial("tcp", node.Address)
+	if err != nil {
+		log.Printf("Error sending PUT to node %s: %v", node.ID, err)
+		g.markNodeDead(node)
+		return
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "PUT %s %s\n", key, value)
+}
+
+// Envia uma operação GET para outro nó e retorna o resultado
+func (g *Gossip) sendGetToNode(node *Node, key string) (string, *vectorclock.VectorClock, bool) {
+	conn, err := net.Dial("tcp", node.Address)
+	if err != nil {
+		log.Printf("Error sending GET to node %s: %v", node.ID, err)
+		g.markNodeDead(node)
+		return "", nil, false
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "GET %s\n", key)
+
+	resp, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		log.Printf("Error reading GET response from node %s: %v", node.ID, err)
+		return "", nil, false
+	}
+
+	resp = strings.TrimSpace(resp)
+	if strings.HasPrefix(resp, "VALUE ") {
+		value := strings.TrimPrefix(resp, "VALUE ")
+		return value, nil, true
+	}
+
+	return "", nil, false
 }

--- a/internal/store/kvstore.go
+++ b/internal/store/kvstore.go
@@ -153,60 +153,71 @@ func (kv *KeyValueStore) writeDataToDisk(key, value string) {
 }
 
 func (kv *KeyValueStore) Put(key, value string) {
-	kv.Mutex.Lock()
-	defer kv.Mutex.Unlock()
-
 	vnode := kv.ConsistentHash.GetNode(key)
 
-	// Se o nó responsável pela chave está offline, fazer hinted handoff
-	if !kv.Gossip.IsNodeAlive(vnode.ID) {
-		log.Printf("Node %s is down. Storing hinted handoff for key %s", vnode.ID, key)
-		kv.HintedData[key] = &Hint{
-			Key:       key,
-			Value:     value,
-			TargetID:  vnode.ID,
-			Timestamp: time.Now(),
+	// Se o nó responsável não for o atual, envia para o nó correto
+	if vnode.ID != kv.Gossip.Self.ID {
+		if !kv.Gossip.IsNodeAlive(vnode.ID) {
+			kv.Mutex.Lock()
+			log.Printf("Node %s is down. Storing hinted handoff for key %s", vnode.ID, key)
+			kv.HintedData[key] = &Hint{
+				Key:       key,
+				Value:     value,
+				TargetID:  vnode.ID,
+				Timestamp: time.Now(),
+			}
+			kv.Mutex.Unlock()
+			return
 		}
+		kv.Gossip.sendPutToNode(vnode, key, value)
 		return
 	}
 
-	// Se a chave já existe, faz merge dos vector clocks
-	if item, exists := kv.Data[key]; exists {
-		item.VectorClock.Increment(kv.Gossip.Self.ID) // Incrementa o Vector Clock local
-		log.Printf("Updated key %s with new value. VectorClock: %s", key, item.VectorClock.String())
-		item.Value = value
-	} else {
-		// Se for um novo dado, cria um Vector Clock e adiciona
-		vc := vectorclock.NewVectorClock()
-		vc.Increment(kv.Gossip.Self.ID)
-		kv.Data[key] = &DataItem{
-			Value:       value,
-			VectorClock: vc,
-		}
-		log.Printf("Stored key %s with initial VectorClock: %s", key, vc.String())
-	}
-
-	// Persistir o dado no disco usando páginas
-	kv.writeDataToDisk(key, value)
+	kv.putLocal(key, value)
 }
 
 func (kv *KeyValueStore) Get(key string) (string, *vectorclock.VectorClock, bool) {
+	vnode := kv.ConsistentHash.GetNode(key)
+
+	if vnode.ID != kv.Gossip.Self.ID {
+		if !kv.Gossip.IsNodeAlive(vnode.ID) {
+			log.Printf("Node %s is down. Key %s might be in hinted handoff.", vnode.ID, key)
+			return "", nil, false
+		}
+		return kv.Gossip.sendGetToNode(vnode, key)
+	}
+
+	return kv.getLocal(key)
+}
+
+// putLocal armazena a chave localmente
+func (kv *KeyValueStore) putLocal(key, value string) {
 	kv.Mutex.Lock()
 	defer kv.Mutex.Unlock()
 
-	vnode := kv.ConsistentHash.GetNode(key)
-
-	// Verifica se o nó responsável está online
-	if kv.Gossip.IsNodeAlive(vnode.ID) {
-		if item, exists := kv.Data[key]; exists {
-			return item.Value, item.VectorClock, true
-		}
-		log.Printf("Key %s not found in node %s", key, vnode.ID)
+	if item, exists := kv.Data[key]; exists {
+		item.VectorClock.Increment(kv.Gossip.Self.ID)
+		log.Printf("Updated key %s with new value. VectorClock: %s", key, item.VectorClock.String())
+		item.Value = value
 	} else {
-		log.Printf("Node %s is down. Key %s might be in hinted handoff.", vnode.ID, key)
+		vc := vectorclock.NewVectorClock()
+		vc.Increment(kv.Gossip.Self.ID)
+		kv.Data[key] = &DataItem{Value: value, VectorClock: vc}
+		log.Printf("Stored key %s with initial VectorClock: %s", key, vc.String())
 	}
 
-	// Se não estiver na memória, tenta carregar do disco
+	kv.writeDataToDisk(key, value)
+}
+
+// getLocal retorna o valor armazenado localmente
+func (kv *KeyValueStore) getLocal(key string) (string, *vectorclock.VectorClock, bool) {
+	kv.Mutex.Lock()
+	defer kv.Mutex.Unlock()
+
+	if item, exists := kv.Data[key]; exists {
+		return item.Value, item.VectorClock, true
+	}
+
 	value, found := kv.readDataFromDisk(key)
 	if found {
 		return value, nil, true


### PR DESCRIPTION
## Summary
- add self node to gossip ring and consistent hash
- forward PUT/GET operations to responsible nodes via TCP
- refactor KV store for local and remote operations

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae69318c0c8322b394884877a9bf8d