### PR TITLE
fix: ensure node3 propagates updates across nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ docker compose exec node1 sh -c "printf 'put chave valor\nexit\n' | kv-g --port 
 
 Substitua `node1` por `node2` ou `node3` para enviar comandos a outros nós.
 
+> Nota: os nós utilizam o próprio ID como hostname (node1, node2, node3).
+> Se estiver executando todos os nós localmente fora do Docker, defina as variáveis de ambiente `NODE1_HOST`, `NODE2_HOST` e `NODE3_HOST` como `localhost` para permitir a comunicação entre eles.
+
 ## Como Testar o Projeto
 
 ### 1. Clonar o Repositório

--- a/main.go
+++ b/main.go
@@ -38,21 +38,34 @@ func main() {
 	runCLI(gossip)
 }
 
+// getNodeAddress retorna o endereço completo de um nó. O hostname pode ser
+// sobrescrito via variável de ambiente <NODE>_HOST (ex: NODE1_HOST), permitindo
+// que cada instância aponte para o host correto em ambientes distribuídos.
+func getNodeAddress(id, port string) string {
+	host := os.Getenv(strings.ToUpper(id) + "_HOST")
+	if host == "" {
+		host = id
+	}
+	return fmt.Sprintf("%s:%s", host, port)
+}
+
 func initializeCluster(nodeID, port string) (*store.Gossip, error) {
-	address := fmt.Sprintf("localhost:%s", port)
+	// Usa o nodeID como hostname para permitir comunicacao entre os nos
+	address := getNodeAddress(nodeID, port)
 
 	gossip := store.NewGossip(nodeID, address, 3*time.Second, 3)
 
-	// Adicionar todos os nós ao cluster
-	if nodeID == "node1" {
-		gossip.AddNode("node2", "localhost:8082")
-		gossip.AddNode("node3", "localhost:8083")
-	} else if nodeID == "node2" {
-		gossip.AddNode("node1", "localhost:8081")
-		gossip.AddNode("node3", "localhost:8083")
-	} else if nodeID == "node3" {
-		gossip.AddNode("node1", "localhost:8081")
-		gossip.AddNode("node2", "localhost:8082")
+	// Adiciona os outros nós ao cluster
+	nodes := map[string]string{
+		"node1": getNodeAddress("node1", "8081"),
+		"node2": getNodeAddress("node2", "8082"),
+		"node3": getNodeAddress("node3", "8083"),
+	}
+
+	for id, addr := range nodes {
+		if id != nodeID {
+			gossip.AddNode(id, addr)
+		}
 	}
 
 	return gossip, nil


### PR DESCRIPTION
## Summary
- use node IDs or overrideable hostnames for gossip addresses so nodes communicate correctly
- document how to configure hostnames when running locally

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae709d57908322b471d616415f00dc