### PR TITLE
fix: default to localhost hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ docker compose exec node1 sh -c "printf 'put chave valor\nexit\n' | kv-g --port 
 
 Substitua `node1` por `node2` ou `node3` para enviar comandos a outros nós.
 
-> Nota: os nós utilizam o próprio ID como hostname (node1, node2, node3).
-> Se estiver executando todos os nós localmente fora do Docker, defina as variáveis de ambiente `NODE1_HOST`, `NODE2_HOST` e `NODE3_HOST` como `localhost` para permitir a comunicação entre eles.
+> Nota: por padrão os nós utilizam `localhost` como hostname para facilitar a execução local.
+> Em ambientes distribuídos, defina as variáveis de ambiente `NODE1_HOST`, `NODE2_HOST` e `NODE3_HOST` para apontar para os hosts corretos.
 
 ## Como Testar o Projeto
 

--- a/main.go
+++ b/main.go
@@ -38,19 +38,20 @@ func main() {
 	runCLI(gossip)
 }
 
-// getNodeAddress retorna o endereço completo de um nó. O hostname pode ser
-// sobrescrito via variável de ambiente <NODE>_HOST (ex: NODE1_HOST), permitindo
-// que cada instância aponte para o host correto em ambientes distribuídos.
+// getNodeAddress retorna o endereço completo de um nó. Por padrão utiliza
+// "localhost" como hostname, mas pode ser sobrescrito via variável de ambiente
+// <NODE>_HOST (ex: NODE1_HOST), permitindo que cada instância aponte para o host
+// correto em ambientes distribuídos.
 func getNodeAddress(id, port string) string {
 	host := os.Getenv(strings.ToUpper(id) + "_HOST")
 	if host == "" {
-		host = id
+		host = "localhost"
 	}
 	return fmt.Sprintf("%s:%s", host, port)
 }
 
 func initializeCluster(nodeID, port string) (*store.Gossip, error) {
-	// Usa o nodeID como hostname para permitir comunicacao entre os nos
+	// Resolve o endereço do nó (por padrão localhost, pode ser sobrescrito via variável de ambiente)
 	address := getNodeAddress(nodeID, port)
 
 	gossip := store.NewGossip(nodeID, address, 3*time.Second, 3)


### PR DESCRIPTION
## Summary
- default to localhost when resolving node hostnames
- update README with hostname configuration instructions

## Testing
- `go test -v ./...`
- `go run main.go --port=8081 --id=node1`


------
https://chatgpt.com/codex/tasks/task_e_68ae73c98c0483229c623dcf1591a5ba